### PR TITLE
fix: set first line of commit message to `githubCommitMessage`

### DIFF
--- a/src/vercel.ts
+++ b/src/vercel.ts
@@ -100,7 +100,8 @@ export const deploy = (octokit?: Octokit) =>
         github.context.payload.pull_request?.head.repo.name ??
           github.context.repo.repo,
       ],
-      ['githubCommitMessage', commitMessage],
+      // メッセージの1行目をgithubCommitMessageに設定
+      ['githubCommitMessage', commitMessage?.trim().split('\n')[0]],
       [
         'githubCommitRef',
         github.context.payload.pull_request?.head?.ref ??


### PR DESCRIPTION
メッセージが複数行存在する場合に、ランナーのOSがWindowsだったときにエラーになるバグも修正されます。