### PR TITLE
fix: set `ignoreError` to `false`

### DIFF
--- a/src/vercel.ts
+++ b/src/vercel.ts
@@ -147,7 +147,7 @@ export const deploy = (octokit?: Octokit) =>
 			command.push("--meta", `${key}=${value}`);
 		}
 
-		const deploymentUrl = await execute(command, { ignoreError: true });
+		const deploymentUrl = await execute(command);
 
 		return deploymentUrl;
 	});


### PR DESCRIPTION
デプロイに失敗しているのに、パスしてしまう問題を修正しました。