### PR TITLE
fix(ci): deploy production from main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
         with:
           token: ${{ secrets.VERCEL_TOKEN }}
           prebuilt: true
-          production: ${{ startsWith(github.ref, 'refs/tags/') && matrix.os == 'ubuntu-latest' }}
+          production: ${{ github.ref == 'refs/heads/main' && matrix.os == 'ubuntu-latest' }}
           project-id: ${{ secrets.VERCEL_PROJECT_ID }}
           org-id: ${{ secrets.VERCEL_ORG_ID }}
 


### PR DESCRIPTION
## Summary

- Fix the production deployment condition in the CI workflow.
- Deploy to Vercel production only for pushes to `refs/heads/main` on `ubuntu-latest`.
- Keep preview deployments on the other matrix OSes and non-main refs.

## Verification

- `pnpm lint`
- `pnpm fmt:check`