### PR TITLE
docs: use Vercel app documentation URL

### DIFF
--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -36316,8 +36316,8 @@ const githubToken = getInput("github-token") || void 0;
 const githubDeploymentEnvironment = getInput("github-deployment-environment") || void 0;
 const buildEnvironments = (0,main.parse)(getInput("build-env"));
 const environments = (0,main.parse)(getInput("env"));
-if (domainAlias.length) warning('"domain-alias" is deprecated. See https://actions-vercel.nexterias.dev/references/inputs/optional/domain-alias');
-if (githubDeploymentEnvironment) warning('"github-deployment-environment" is deprecated. See https://actions-vercel.nexterias.dev/references/inputs/optional/github-deployment-environment');
+if (domainAlias.length) warning('"domain-alias" is deprecated. See https://actions-vercel.vercel.app/references/inputs/optional/domain-alias');
+if (githubDeploymentEnvironment) warning('"github-deployment-environment" is deprecated. See https://actions-vercel.vercel.app/references/inputs/optional/github-deployment-environment');
 
 ;// CONCATENATED MODULE: ./src/github/comment.ts
 

--- a/src/input.ts
+++ b/src/input.ts
@@ -16,9 +16,9 @@ export const environments = parseDotenv(core.getInput("env"));
 
 if (domainAlias.length)
   core.warning(
-    '"domain-alias" is deprecated. See https://actions-vercel.nexterias.dev/references/inputs/optional/domain-alias',
+    '"domain-alias" is deprecated. See https://actions-vercel.vercel.app/references/inputs/optional/domain-alias',
   );
 if (githubDeploymentEnvironment)
   core.warning(
-    '"github-deployment-environment" is deprecated. See https://actions-vercel.nexterias.dev/references/inputs/optional/github-deployment-environment',
+    '"github-deployment-environment" is deprecated. See https://actions-vercel.vercel.app/references/inputs/optional/github-deployment-environment',
   );


### PR DESCRIPTION
## Summary

- update the two deprecated input warning links to `https://actions-vercel.vercel.app`
- regenerate `dist/index.mjs`
- remove the old documentation domain from the source and distribution bundle

## Scope

This PR covers the repository changes for #416. The GitHub repository Homepage and Vercel domain redirect were configured separately, and all Issue #416 TODO items are now complete.

## Verification

- `pnpm lint`
- `pnpm fmt:check`
- `pnpm build`
- `git diff --check`

Refs #416