### PR TITLE
docs: improve README and workflow examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,10 @@ Deploy to Vercel with GitHub Actions
 
 ## Features
 
-- Switch between preview and production deployments.
-- Deploy the build result from GitHub Actions with `prebuilt: true`.
-- Integrate deployments with pull request comments, commit statuses, and GitHub Deployments.
-- Add custom steps such as tests and notifications before or after deployment.
-- Configure the working directory and build-time or runtime environment variables.
+- 🚀 Switch between preview and production deployments.
+- 🏗️ Deploy the build result from GitHub Actions with `prebuilt: true`.
+- 🔗 Integrate deployments with pull request comments, commit statuses, and GitHub Deployments.
+- 🧩 Add custom steps such as tests and notifications before or after deployment.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Deploy to Vercel with GitHub Actions
 - 🔗 Integrate deployments with pull request comments, commit statuses, and GitHub Deployments.
 - 🧩 Add custom steps such as tests and notifications before or after deployment.
 
+## Documentation
+
+See the [documentation](https://actions-vercel.nexterias.dev/) for detailed setup instructions and reference information.
+
 ## Usage
 
 ```yml

--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@
 
 Deploy to Vercel with GitHub Actions
 
+## Overview
+
+`nexterias/actions-vercel` is a GitHub Action that deploys Vercel projects from GitHub Actions. By building the project on the GitHub Actions runner when necessary and deploying it to Vercel, it can reduce Vercel-side build time to zero.
+
+## Features
+
+- Switch between preview and production deployments.
+- Deploy the build result from GitHub Actions with `prebuilt: true`.
+- Integrate deployments with pull request comments, commit statuses, and GitHub Deployments.
+- Add custom steps such as tests and notifications before or after deployment.
+- Configure the working directory and build-time or runtime environment variables.
+
 ## Usage
 
 ```yml

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
 
       - uses: nexterias/actions-vercel@v2
         with:
@@ -42,3 +42,4 @@ jobs:
 ## Examples
 
 - [nexterias/homepage](https://github.com/nexterias/homepage)
+- [Projects using actions-vercel (GitHub Code Search)](https://github.com/search?q=%22nexterias%2Factions-vercel%22+path%3A.github%2Fworkflows+-is%3Afork+-repo%3Anexterias%2Factions-vercel&type=code)

--- a/README.md
+++ b/README.md
@@ -41,5 +41,4 @@ jobs:
 
 ## Examples
 
-- [nexterias/homepage](https://github.com/nexterias/homepage)
-- [Projects using actions-vercel (GitHub Code Search)](https://github.com/search?q=%22nexterias%2Factions-vercel%22+path%3A.github%2Fworkflows+-is%3Afork+-repo%3Anexterias%2Factions-vercel&type=code)
+- [List of projects using actions-vercel](https://github.com/search?q=%22nexterias%2Factions-vercel%22+path%3A.github%2Fworkflows+-is%3Afork+-repo%3Anexterias%2Factions-vercel&type=code)

--- a/README.md
+++ b/README.md
@@ -15,10 +15,6 @@ Deploy to Vercel with GitHub Actions
 - 🔗 Integrate deployments with pull request comments, commit statuses, and GitHub Deployments.
 - 🧩 Add custom steps such as tests and notifications before or after deployment.
 
-## Documentation
-
-See the [documentation](https://actions-vercel.nexterias.dev/) for detailed setup instructions and reference information.
-
 ## Usage
 
 ```yml
@@ -53,6 +49,10 @@ jobs:
           production: ${{ github.ref == 'refs/heads/main' }}
           prebuilt: true # If set to true, build will be performed using GitHub Actions.
 ```
+
+## Documentation
+
+See the [documentation](https://actions-vercel.nexterias.dev/) for detailed setup instructions and reference information.
 
 ## Examples
 

--- a/docs/content/snippets/basic-workflow.yml
+++ b/docs/content/snippets/basic-workflow.yml
@@ -20,7 +20,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: nexterias/actions-vercel@v2
         with:

--- a/docs/content/snippets/references/inputs/build-env.yml
+++ b/docs/content/snippets/references/inputs/build-env.yml
@@ -20,7 +20,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: nexterias/actions-vercel@v2
         with:

--- a/docs/content/snippets/references/inputs/cwd.yml
+++ b/docs/content/snippets/references/inputs/cwd.yml
@@ -20,7 +20,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: nexterias/actions-vercel@v2
         with:

--- a/docs/content/snippets/references/inputs/env.yml
+++ b/docs/content/snippets/references/inputs/env.yml
@@ -20,7 +20,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: nexterias/actions-vercel@v2
         with:

--- a/docs/content/snippets/references/inputs/github-token.yml
+++ b/docs/content/snippets/references/inputs/github-token.yml
@@ -20,7 +20,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: nexterias/actions-vercel@v2
         with:

--- a/docs/content/snippets/references/inputs/prebuilt.yml
+++ b/docs/content/snippets/references/inputs/prebuilt.yml
@@ -20,7 +20,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: nexterias/actions-vercel@v2
         with:

--- a/docs/content/snippets/references/inputs/production.yml
+++ b/docs/content/snippets/references/inputs/production.yml
@@ -20,7 +20,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: nexterias/actions-vercel@v2
         with:

--- a/docs/content/snippets/references/inputs/public.yml
+++ b/docs/content/snippets/references/inputs/public.yml
@@ -20,7 +20,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: nexterias/actions-vercel@v2
         with:

--- a/docs/content/snippets/references/outputs/deployment-status.yml
+++ b/docs/content/snippets/references/outputs/deployment-status.yml
@@ -20,7 +20,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: nexterias/actions-vercel@v2
         id: vercel

--- a/docs/content/snippets/references/outputs/deployment-url.yml
+++ b/docs/content/snippets/references/outputs/deployment-url.yml
@@ -20,7 +20,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: nexterias/actions-vercel@v2
         id: vercel


### PR DESCRIPTION
## Summary

- Update README.md and documentation workflow snippets to use actions/checkout@v7.
- Add README Overview and Features sections.
- Add a GitHub Code Search link for projects using actions-vercel.
- Remove the archived nexterias/homepage example.

## Verification

- pnpm lint
- pnpm fmt:check
- git diff --check
- Confirmed no actions/checkout@v3 or actions/checkout@v4 references remain.

Closes #511