### PR TITLE
chore(ci): use app token for protected main updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,22 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
     steps:
+      - name: Generate GitHub App token
+        if: ${{ github.ref == 'refs/heads/main' }}
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          client-id: ${{ secrets.RELEASE_PLEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: actions-vercel
+          permission-contents: write
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          token: ${{ steps.app-token.outputs.token || github.token }}
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
 


### PR DESCRIPTION
## Summary

- generate an installation token for the `actions-vercel` GitHub App on `main` pushes
- persist that token through checkout so the generated `dist` commit can bypass the main ruleset
- keep pull request runs on the read-only `GITHUB_TOKEN` fallback

## Verification

- `pnpm lint`
- `pnpm fmt:check`
- `actionlint .github/workflows/ci.yml`